### PR TITLE
Update utils.R

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -128,7 +128,7 @@ translate_matrix <- function(exp, species, verbose = TRUE){
 
     xref <- load_xref(species)
 
-    new_ids <- gsub("\\.[0123456789]$", "", rownames(exp))
+    new_ids <- gsub("\\.[0123456789]+$", "", rownames(exp))
 
     # translate ids
     tt <- translate_ids(new_ids, xref)


### PR DESCRIPTION
With this change, Ensembl ids with more than one digit after the '.' can also be cropped (line 131).

Example of dataset where this becomes useful (GTEx database): https://storage.googleapis.com/gtex_analysis_v8/rna_seq_data/GTEx_Analysis_2017-06-05_v8_RNASeQCv1.1.9_gene_reads.gct.gz
IDs such as "ENSG00000172283.10" from the dataset above will get cropped (to "ENSG00000172283") instead of being ignored.